### PR TITLE
fix: update Azure AD B2C policy name from _201 to _209

### DIFF
--- a/src/costco_mcp_server/auth.py
+++ b/src/costco_mcp_server/auth.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # Azure AD B2C static configuration for Costco
 TENANT_ID = "e0714dd4-784d-46d6-a278-3e29553483eb"
-POLICY_NAME = "b2c_1a_sso_wcs_signup_signin_201"
+POLICY_NAME = "b2c_1a_sso_wcs_signup_signin_209"
 TOKEN_ENDPOINT = f"https://signin.costco.com/{TENANT_ID}/{POLICY_NAME}/oauth2/v2.0/token"
 
 # Client IDs


### PR DESCRIPTION
## Summary
- Costco has moved their Azure AD B2C sign-in policy from `b2c_1a_sso_wcs_signup_signin_201` to `_209`. Refresh tokens minted by the current browser SPA are issued under `_209`, so every `save_refresh_token` + `get_bearer_token` call now fails at the token endpoint with `AADB2C90088: The provided grant has not been issued for this endpoint` (400).
- Updates `POLICY_NAME` in `auth.py` to match.

## Verification
Posted the same real refresh token (extracted from a live browser session's localStorage) directly to both token endpoints:

- `.../b2c_1a_sso_wcs_signup_signin_201/oauth2/v2.0/token` → `400 invalid_grant`, `AADB2C90088 ... Expected Value: B2C_1A_SSO_WCS_signup_signin_201`
- `.../b2c_1a_sso_wcs_signup_signin_209/oauth2/v2.0/token` → `200 OK` with a valid `id_token`

After the fix, `list_warehouse_receipts` / `get_all_receipt_details` / `list_online_orders` all succeed against a real account.

## Test plan
- [x] Manually verified token exchange against both policy endpoints
- [x] Manually verified `list_warehouse_receipts` returns real receipt data with the patched policy name
- [ ] No automated tests exist in this repo for the auth flow (per `CLAUDE.md`, "Tests are not checked in")